### PR TITLE
Colon in "Writeup: 3D Printing Class" post title messing up layout.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,7 +12,7 @@
     <meta property="og:type" content="blog"/>
 
 
-    <base href="http://hacksburg.org/">
+    <base href="{{ site.url }}"/>
     <link rel="shortcut icon" href="/favicon.png">
     <link rel="alternate" type="application/rss+xml" title="RSS" href="/feed.xml">
 

--- a/_posts/2015-10-26-1209-writeup_3d_printing_class.markdown
+++ b/_posts/2015-10-26-1209-writeup_3d_printing_class.markdown
@@ -1,5 +1,5 @@
 ---
-title: Writeup: 3D Printing Class
+title: 'Writeup: 3D Printing Class'
 author: Andrew Mike
 date: 2015-10-26
 layout: post


### PR DESCRIPTION
Colon in 3d printing post title was messing up markdown, added single quotes around title.
Changed static site url to {{ site.url }} in default layout