### PR TITLE
RSS regex matches when price is omitted.

### DIFF
--- a/rss_to_json.ipynb
+++ b/rss_to_json.ipynb
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "# Define regex for parsing description field (includes date, time, description, number of attendees, price, etc)\n",
-    "expression = re.compile('.*<p><p>(?P<description>.*)<\\/p> <\\/p> <p>(?P<location>.*)<\\/p> <p>(?P<date>.*)<\\/p> <p>(?P<attendees>.*)<\\/p> <p>Price: (?P<price>[0-9]+).*<\\/p> <p>(?P<url>.*)<\\/p>.*')\n",
+    "expression = re.compile('.*<p><p>(?P<description>.*)<\\/p> <\\/p> <p>(?P<location>.*)<\\/p> <p>(?P<date>.*)<\\/p> <p>(?P<attendees>.*)<\\/p>( <p>Price: (?P<price>[0-9]+).*?<\\/p>)? <p>(?P<url>.*)<\\/p> ]]>.*')\n",
     "\n",
     "# Initialize empty frame for collecting events\n",
     "output = pandas.DataFrame()\t\n",


### PR DESCRIPTION
Fix for issue #30. I wrapped the `Price` field in an unnamed capture group. If `Price` is omitted from the RSS, the `price` capture group will be `None`. I assume you'll handle rendering that in the caller.