### PR TITLE
Regex fix

### DIFF
--- a/rss_to_json.ipynb
+++ b/rss_to_json.ipynb
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "# Define regex for parsing description field (includes date, time, description, number of attendees, price, etc)\n",
-    "expression = re.compile('.*<p><p>(?P<description>.*)<\\/p> <\\/p> <p>(?P<location>.*)<\\/p> <p>(?P<date>.*)<\\/p> <p>(?P<attendees>.*)<\\/p>( <p>Price: (?P<price>[0-9]+).*?<\\/p>)? <p>(?P<url>.*)<\\/p> ]]>.*')\n",
+    "expression = re.compile('.*<p><p>(?P<description>.*)<\\/p> <\\/p> <p>(?P<location>.*?)<\\/p> <p>(?P<date>.*?)<\\/p> <p>(?P<attendees>.*?)<\\/p>( <p>Price: (?P<price>[0-9]+).*?<\\/p>)? <p>(?P<url>.*)<\\/p> ]]>.*')\n",
     "\n",
     "# Initialize empty frame for collecting events\n",
     "output = pandas.DataFrame()\t\n",

--- a/rss_to_json.ipynb
+++ b/rss_to_json.ipynb
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "# Define regex for parsing description field (includes date, time, description, number of attendees, price, etc)\n",
-    "expression = re.compile('.*<p><p>(?P<description>.*)<\\/p> <\\/p> <p>(?P<location>.*)<\\/p> <p>(?P<date>.*)<\\/p> <p>(?P<attendees>.*)<\\/p> <p>Price: (?P<price>[0-9]+).*<\\/p> <p>(?P<url>.*)<\\/p>.*')\n",
+    "expression = re.compile('.*<p><p>(?P<description>.*)<\\/p> <\\/p> <p>(?P<location>.*)<\\/p> <p>(?P<date>.*)<\\/p> <p>(?P<attendees>.*)<\\/p>( <p>Price: (?P<price>[0-9]+).*?<\\/p>)? <p>(?P<url>.*)<\\/p> ]]>.*')\n",
     "\n",
     "# Initialize empty frame for collecting events\n",
     "output = pandas.DataFrame()\t\n",


### PR DESCRIPTION
Fix for issue #30. RSS to JSON regex should match RSS descriptions when the `Price` field is absent. Tested against https://regex101.com/r/HLCFll/3 ; this combination of lazy and greedy quantifiers seems to minimize the number of steps to match the test strings.