### PR TITLE
minor modifications to posts

### DIFF
--- a/build.py
+++ b/build.py
@@ -61,7 +61,7 @@ def json_to_html():
 
 	html = ""
 	for post in posts:
-		date = datetime.strptime(post["date"], '%Y-%m-%d')
+		date = datetime.strptime(f"{post['date']} {datetime.strptime(post['end_time'], '%I:%M%p').strftime('%H:%M')}", '%Y-%m-%d %H:%M')
 		start_time = post["start_time"]
 		end_time = post["end_time"]
 		cancelled = post["cancelled"]

--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-import json, os, shutil, urllib.parse
+import json, os, shutil, urllib.parse, hashlib
 from datetime import datetime
 
 def sort_posts():
@@ -67,7 +67,7 @@ def json_to_html():
 		cancelled = post["cancelled"]
 
 		# Header
-		html += f'\n\t\t\t\t\t<div class="post" data-isodate="{date}">\n'
+		html += f'\n\t\t\t\t\t<div class="post" data-isodate="{date}" ' + f'data-hash="{generate_hash(post["title"] + start_time)}">\n'
 		html += '\t\t\t\t\t\t<div class="post_header">\n'
 		
 		if date and start_time and end_time:
@@ -169,6 +169,9 @@ def json_to_html():
 		
 	return html
 
+def generate_hash(str):
+	return hashlib.sha256(str.encode()).hexdigest()[:8]
+
 def announcements_to_html():
 	with open('posts.json') as json_file:
 		data = json.load(json_file)
@@ -176,7 +179,7 @@ def announcements_to_html():
 
 	html = ""
 	for post in posts:
-		html += f'\n\t\t\t\t\t<div class="post">\n'
+		html += f'\n\t\t\t\t\t<div class="post" ' + f'data-hash="{generate_hash(post["title"])}">\n'
 		html += '\t\t\t\t\t\t<div class="post_header">\n'
 		html += '\t\t\t\t\t\t\t<div class="title_and_subtitle">\n'
 		html += f'\t\t\t\t\t\t\t\t<div class="title">{post["title"]}</div>\n'

--- a/build.py
+++ b/build.py
@@ -67,7 +67,7 @@ def json_to_html():
 		cancelled = post["cancelled"]
 
 		# Header
-		html += f'\n\t\t\t\t\t<div class="post" data-isodate="{date}" ' + f'data-hash="{generate_hash(post["title"] + start_time)}">\n'
+		html += f'\n\t\t\t\t\t<div class="post" data-isodate="{date}">\n'
 		html += '\t\t\t\t\t\t<div class="post_header">\n'
 		
 		if date and start_time and end_time:
@@ -169,9 +169,6 @@ def json_to_html():
 		
 	return html
 
-def generate_hash(str):
-	return hashlib.sha256(str.encode()).hexdigest()[:8]
-
 def announcements_to_html():
 	with open('posts.json') as json_file:
 		data = json.load(json_file)
@@ -179,7 +176,7 @@ def announcements_to_html():
 
 	html = ""
 	for post in posts:
-		html += f'\n\t\t\t\t\t<div class="post" ' + f'data-hash="{generate_hash(post["title"])}">\n'
+		html += f'\n\t\t\t\t\t<div class="post">\n'
 		html += '\t\t\t\t\t\t<div class="post_header">\n'
 		html += '\t\t\t\t\t\t\t<div class="title_and_subtitle">\n'
 		html += f'\t\t\t\t\t\t\t\t<div class="title">{post["title"]}</div>\n'

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
 
 					<!-- FEED START !-->
 
-					<div class="post" data-isodate="2023-10-31 00:00:00">
+					<div class="post" data-isodate="2023-10-31 21:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">31</div>
@@ -122,7 +122,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-10-29 00:00:00">
+					<div class="post" data-isodate="2023-10-29 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">29</div>
@@ -158,7 +158,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-10-24 00:00:00">
+					<div class="post" data-isodate="2023-10-24 21:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">24</div>
@@ -189,7 +189,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-10-22 00:00:00">
+					<div class="post" data-isodate="2023-10-22 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">22</div>
@@ -225,7 +225,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-10-15 00:00:00">
+					<div class="post" data-isodate="2023-10-15 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">15</div>
@@ -261,7 +261,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-10-10 00:00:00">
+					<div class="post" data-isodate="2023-10-10 21:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">10</div>
@@ -292,7 +292,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-10-03 00:00:00">
+					<div class="post" data-isodate="2023-10-03 21:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">3</div>
@@ -323,7 +323,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-10-01 00:00:00">
+					<div class="post" data-isodate="2023-10-01 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">1</div>
@@ -359,7 +359,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-09-30 00:00:00">
+					<div class="post" data-isodate="2023-09-30 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">30</div>
@@ -396,7 +396,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-09-26 00:00:00">
+					<div class="post" data-isodate="2023-09-26 21:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">26</div>
@@ -427,7 +427,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-09-24 00:00:00">
+					<div class="post" data-isodate="2023-09-24 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">24</div>
@@ -463,7 +463,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-09-23 00:00:00">
+					<div class="post" data-isodate="2023-09-23 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">23</div>
@@ -499,7 +499,43 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-09-17 00:00:00">
+					<div class="post" data-isodate="2023-09-23 16:00:00">
+						<div class="post_header">
+							<div class="calendar_link noselect">
+								<div class="circled_date">23</div>
+								<div class="month_and_time">September<br>
+									<div class="time">2:00 - 4:00pm</div>
+								</div>
+							</div>
+							<div class="title_and_subtitle_wrapper">
+								<div class="title_and_subtitle">
+									<div class="title">Laser Cutter 101</div>
+									<div class="subtitle">Make Your Own Edge-Lit Acrylic Sign</div>
+								</div>
+							</div>
+							<div class="x_box" onClick="togglePostOpened(this)">
+								<div class="x"></div>
+							</div>
+						</div>
+						<div class="closeable">
+							<div class="post_body">
+								<img class="post_image" src="/resources/images/laser_3.jpg" loading="lazy">
+								<div class="post_text"><p>This workshop covers the Hacksburg 80W CO2 laser cutter. Basic laser safety, design guidelines, and examples will be presented. Attendees will learn how to make their own edge-lit acrylic sign and receive the LED base with the optional materials fee.</p> <p>Free for members and $5 for non-members, plus $10 optional materials fee.</p><p><b>This event has been rescheduled</b></p>
+									<p>
+									<b>Time</b>: Saturday, September 23rd from 2:00 - 4:00pm<br>
+									<b>Place</b>: In person at Hacksburg; <a href="https://www.google.com/maps/dir/?api=1&destination=Hacksburg+Blacksburg,+VA" target="_blank">1872 Pratt Drive Suite 1620</a>. Enter through the covered double doors at the back of the building.<br>
+									<b>Cost</b>: $10 for Hacksburg members; $15 for non-members. Pay in person or online at <a href="https://paypal.me/hacksburg" target="_blank">paypal.me/hacksburg</a>.
+									</p>
+									<a class="button rsvp_button" href="https://www.meetup.com/hacksburgva/events/295657648/" target="_blank">RSVP on Meetup</a>
+									<div class="below_button_text">
+										or <a href="mailto:rsvp@hacksburg.org?subject=RSVP%20for%20Laser%20Cutter%20101&body=I%20am%20confirming%20my%20RSVP%20for%20%22Laser%20Cutter%20101%22%20on%20Saturday%2C%20September%2023rd%20from%202%3A00%20-%204%3A00pm." target="_blank">RSVP by Email</a>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+
+					<div class="post" data-isodate="2023-09-17 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">17</div>
@@ -535,7 +571,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-09-12 00:00:00">
+					<div class="post" data-isodate="2023-09-12 23:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">12</div>
@@ -571,43 +607,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-09-10 00:00:00">
-						<div class="post_header">
-							<div class="calendar_link noselect">
-								<div class="circled_date">10</div>
-								<div class="month_and_time">September<br>
-									<div class="time">1:00 - 4:00pm</div>
-								</div>
-							</div>
-							<div class="title_and_subtitle_wrapper">
-								<div class="title_and_subtitle">
-									<div class="title">Laser Cutter 101</div>
-									<div class="subtitle">Make Your Own Edge-Lit Acrylic Sign</div>
-								</div>
-							</div>
-							<div class="x_box" onClick="togglePostOpened(this)">
-								<div class="x"></div>
-							</div>
-						</div>
-						<div class="closeable">
-							<div class="post_body">
-								<img class="post_image" src="/resources/images/laser_3.jpg" loading="lazy">
-								<div class="post_text"><p>This workshop covers the Hacksburg 80W CO2 laser cutter. Basic laser safety, design guidelines, and examples will be presented. Attendees will learn how to make their own edge-lit acrylic sign and receive the LED base with the optional materials fee.</p> <p>Free for members and $5 for non-members, plus $10 optional materials fee.</p>
-									<p>
-									<b>Time</b>: Sunday, September 10th from 1:00 - 4:00pm<br>
-									<b>Place</b>: In person at Hacksburg; <a href="https://www.google.com/maps/dir/?api=1&destination=Hacksburg+Blacksburg,+VA" target="_blank">1872 Pratt Drive Suite 1620</a>. Enter through the covered double doors at the back of the building.<br>
-									<b>Cost</b>: $10 for Hacksburg members; $15 for non-members. Pay in person or online at <a href="https://paypal.me/hacksburg" target="_blank">paypal.me/hacksburg</a>.
-									</p>
-									<a class="button rsvp_button" href="https://www.meetup.com/hacksburgva/events/295657648/" target="_blank">RSVP on Meetup</a>
-									<div class="below_button_text">
-										or <a href="mailto:rsvp@hacksburg.org?subject=RSVP%20for%20Laser%20Cutter%20101&body=I%20am%20confirming%20my%20RSVP%20for%20%22Laser%20Cutter%20101%22%20on%20Sunday%2C%20September%2010th%20from%201%3A00%20-%204%3A00pm." target="_blank">RSVP by Email</a>
-									</div>
-								</div>
-							</div>
-						</div>
-					</div>
-
-					<div class="post" data-isodate="2023-09-06 00:00:00">
+					<div class="post" data-isodate="2023-09-06 18:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">6</div>
@@ -643,7 +643,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-08-27 00:00:00">
+					<div class="post" data-isodate="2023-08-27 16:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">27</div>
@@ -679,7 +679,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-08-20 00:00:00">
+					<div class="post" data-isodate="2023-08-20 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">20</div>
@@ -715,7 +715,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-08-15 00:00:00">
+					<div class="post" data-isodate="2023-08-15 21:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">15</div>
@@ -746,7 +746,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-08-13 00:00:00">
+					<div class="post" data-isodate="2023-08-13 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">13</div>
@@ -782,7 +782,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-08-08 00:00:00">
+					<div class="post" data-isodate="2023-08-08 21:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">8</div>
@@ -813,7 +813,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-08-06 00:00:00">
+					<div class="post" data-isodate="2023-08-06 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">6</div>
@@ -842,7 +842,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-08-01 00:00:00">
+					<div class="post" data-isodate="2023-08-01 21:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">1</div>
@@ -873,7 +873,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-07-25 00:00:00">
+					<div class="post" data-isodate="2023-07-25 21:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">25</div>
@@ -904,7 +904,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-07-23 00:00:00">
+					<div class="post" data-isodate="2023-07-23 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">23</div>
@@ -940,7 +940,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-07-18 00:00:00">
+					<div class="post" data-isodate="2023-07-18 21:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">18</div>
@@ -971,7 +971,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-07-16 00:00:00">
+					<div class="post" data-isodate="2023-07-16 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">16</div>
@@ -1007,7 +1007,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-07-11 00:00:00">
+					<div class="post" data-isodate="2023-07-11 21:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">11</div>
@@ -1038,7 +1038,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-07-09 00:00:00">
+					<div class="post" data-isodate="2023-07-09 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">9</div>
@@ -1074,7 +1074,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-06-25 00:00:00">
+					<div class="post" data-isodate="2023-06-25 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">25</div>
@@ -1110,7 +1110,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-06-18 00:00:00">
+					<div class="post" data-isodate="2023-06-18 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">18</div>
@@ -1146,7 +1146,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-06-17 00:00:00">
+					<div class="post" data-isodate="2023-06-17 23:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">17</div>
@@ -1182,7 +1182,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-06-04 00:00:00">
+					<div class="post" data-isodate="2023-06-04 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">4</div>
@@ -1218,7 +1218,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-05-21 00:00:00">
+					<div class="post" data-isodate="2023-05-21 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">21</div>
@@ -1254,7 +1254,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-05-07 00:00:00">
+					<div class="post" data-isodate="2023-05-07 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">7</div>
@@ -1290,7 +1290,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-04-30 00:00:00">
+					<div class="post" data-isodate="2023-04-30 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">30</div>
@@ -1326,7 +1326,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-04-04 00:00:00">
+					<div class="post" data-isodate="2023-04-04 22:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">4</div>
@@ -1362,7 +1362,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-04-02 00:00:00">
+					<div class="post" data-isodate="2023-04-02 16:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">2</div>
@@ -1398,7 +1398,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-03-19 00:00:00">
+					<div class="post" data-isodate="2023-03-19 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">19</div>

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
 					<!-- ANNOUNCEMENTS START !-->
 					<!-- ANNOUNCEMENTS END !-->
 
-					<div class="post pinned" data-hash="d5d576d3">
+					<div class="post pinned">
 						<div class="post_header">
 							<div class="title_and_subtitle">
 								<div class="title">Hacksburg is Blacksburg's Makerspace</div>
@@ -91,7 +91,7 @@
 
 					<!-- FEED START !-->
 
-					<div class="post" data-isodate="2023-10-31 21:30:00" data-hash="a48f6d9d">
+					<div class="post" data-isodate="2023-10-31 21:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">31</div>
@@ -122,7 +122,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-10-29 16:00:00" data-hash="2dacc76a">
+					<div class="post" data-isodate="2023-10-29 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">29</div>
@@ -158,7 +158,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-10-24 21:30:00" data-hash="97e25216">
+					<div class="post" data-isodate="2023-10-24 21:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">24</div>
@@ -189,7 +189,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-10-22 16:00:00" data-hash="9374c720">
+					<div class="post" data-isodate="2023-10-22 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">22</div>
@@ -225,7 +225,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-10-15 16:00:00" data-hash="9374c720">
+					<div class="post" data-isodate="2023-10-15 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">15</div>
@@ -261,7 +261,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-10-10 21:30:00" data-hash="99a8ce34">
+					<div class="post" data-isodate="2023-10-10 21:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">10</div>
@@ -292,7 +292,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-10-03 21:30:00" data-hash="9a2e2d52">
+					<div class="post" data-isodate="2023-10-03 21:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">3</div>
@@ -323,7 +323,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-10-01 16:00:00" data-hash="a265e24d">
+					<div class="post" data-isodate="2023-10-01 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">1</div>
@@ -359,7 +359,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-09-30 16:00:00" data-hash="dfc19e06">
+					<div class="post" data-isodate="2023-09-30 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">30</div>
@@ -396,7 +396,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-09-26 21:30:00" data-hash="a2fca8e3">
+					<div class="post" data-isodate="2023-09-26 21:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">26</div>
@@ -427,7 +427,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-09-24 16:00:00" data-hash="245f1f2c">
+					<div class="post" data-isodate="2023-09-24 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">24</div>
@@ -463,7 +463,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-09-23 16:00:00" data-hash="1555189d">
+					<div class="post" data-isodate="2023-09-23 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">23</div>
@@ -499,7 +499,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-09-23 16:00:00" data-hash="b6828b26">
+					<div class="post" data-isodate="2023-09-23 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">23</div>
@@ -535,7 +535,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-09-17 16:00:00" data-hash="48300cbc">
+					<div class="post" data-isodate="2023-09-17 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">17</div>
@@ -571,7 +571,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-09-12 23:30:00" data-hash="eb54167a">
+					<div class="post" data-isodate="2023-09-12 23:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">12</div>
@@ -607,7 +607,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-09-06 18:00:00" data-hash="cae3a88c">
+					<div class="post" data-isodate="2023-09-06 18:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">6</div>
@@ -643,7 +643,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-08-27 16:30:00" data-hash="e66aa61b">
+					<div class="post" data-isodate="2023-08-27 16:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">27</div>
@@ -679,7 +679,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-08-20 16:00:00" data-hash="4da9329d">
+					<div class="post" data-isodate="2023-08-20 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">20</div>
@@ -715,7 +715,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-08-15 21:30:00" data-hash="6323f1be">
+					<div class="post" data-isodate="2023-08-15 21:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">15</div>
@@ -746,7 +746,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-08-13 16:00:00" data-hash="245f1f2c">
+					<div class="post" data-isodate="2023-08-13 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">13</div>
@@ -782,7 +782,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-08-08 21:30:00" data-hash="953163de">
+					<div class="post" data-isodate="2023-08-08 21:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">8</div>
@@ -813,7 +813,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-08-06 16:00:00" data-hash="335c9857">
+					<div class="post" data-isodate="2023-08-06 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">6</div>
@@ -842,7 +842,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-08-01 21:30:00" data-hash="1ce8aba2">
+					<div class="post" data-isodate="2023-08-01 21:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">1</div>
@@ -873,7 +873,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-07-25 21:30:00" data-hash="759bebeb">
+					<div class="post" data-isodate="2023-07-25 21:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">25</div>
@@ -904,7 +904,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-07-23 16:00:00" data-hash="f356998b">
+					<div class="post" data-isodate="2023-07-23 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">23</div>
@@ -940,7 +940,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-07-18 21:30:00" data-hash="dbcd2f7b">
+					<div class="post" data-isodate="2023-07-18 21:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">18</div>
@@ -971,7 +971,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-07-16 16:00:00" data-hash="e560abc1">
+					<div class="post" data-isodate="2023-07-16 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">16</div>
@@ -1007,7 +1007,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-07-11 21:30:00" data-hash="12cb9928">
+					<div class="post" data-isodate="2023-07-11 21:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">11</div>
@@ -1038,7 +1038,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-07-09 16:00:00" data-hash="a265e24d">
+					<div class="post" data-isodate="2023-07-09 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">9</div>
@@ -1074,7 +1074,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-06-25 16:00:00" data-hash="d6113cce">
+					<div class="post" data-isodate="2023-06-25 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">25</div>
@@ -1110,7 +1110,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-06-18 16:00:00" data-hash="d85be19b">
+					<div class="post" data-isodate="2023-06-18 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">18</div>
@@ -1146,7 +1146,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-06-17 23:00:00" data-hash="0b3631e5">
+					<div class="post" data-isodate="2023-06-17 23:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">17</div>
@@ -1182,7 +1182,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-06-04 16:00:00" data-hash="7d44116d">
+					<div class="post" data-isodate="2023-06-04 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">4</div>
@@ -1218,7 +1218,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-05-21 16:00:00" data-hash="e8129134">
+					<div class="post" data-isodate="2023-05-21 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">21</div>
@@ -1254,7 +1254,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-05-07 16:00:00" data-hash="9355f65c">
+					<div class="post" data-isodate="2023-05-07 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">7</div>
@@ -1290,7 +1290,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-04-30 16:00:00" data-hash="5e818028">
+					<div class="post" data-isodate="2023-04-30 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">30</div>
@@ -1326,7 +1326,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-04-04 22:30:00" data-hash="b7210621">
+					<div class="post" data-isodate="2023-04-04 22:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">4</div>
@@ -1362,7 +1362,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-04-02 16:30:00" data-hash="e66aa61b">
+					<div class="post" data-isodate="2023-04-02 16:30:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">2</div>
@@ -1398,7 +1398,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-03-19 16:00:00" data-hash="6fb9ebb9">
+					<div class="post" data-isodate="2023-03-19 16:00:00">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">19</div>

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
 					<!-- ANNOUNCEMENTS START !-->
 					<!-- ANNOUNCEMENTS END !-->
 
-					<div class="post pinned">
+					<div class="post pinned" data-hash="d5d576d3">
 						<div class="post_header">
 							<div class="title_and_subtitle">
 								<div class="title">Hacksburg is Blacksburg's Makerspace</div>
@@ -91,7 +91,7 @@
 
 					<!-- FEED START !-->
 
-					<div class="post" data-isodate="2023-10-31 21:30:00">
+					<div class="post" data-isodate="2023-10-31 21:30:00" data-hash="a48f6d9d">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">31</div>
@@ -122,7 +122,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-10-29 16:00:00">
+					<div class="post" data-isodate="2023-10-29 16:00:00" data-hash="2dacc76a">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">29</div>
@@ -158,7 +158,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-10-24 21:30:00">
+					<div class="post" data-isodate="2023-10-24 21:30:00" data-hash="97e25216">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">24</div>
@@ -189,7 +189,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-10-22 16:00:00">
+					<div class="post" data-isodate="2023-10-22 16:00:00" data-hash="9374c720">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">22</div>
@@ -225,7 +225,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-10-15 16:00:00">
+					<div class="post" data-isodate="2023-10-15 16:00:00" data-hash="9374c720">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">15</div>
@@ -261,7 +261,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-10-10 21:30:00">
+					<div class="post" data-isodate="2023-10-10 21:30:00" data-hash="99a8ce34">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">10</div>
@@ -292,7 +292,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-10-03 21:30:00">
+					<div class="post" data-isodate="2023-10-03 21:30:00" data-hash="9a2e2d52">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">3</div>
@@ -323,7 +323,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-10-01 16:00:00">
+					<div class="post" data-isodate="2023-10-01 16:00:00" data-hash="a265e24d">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">1</div>
@@ -359,7 +359,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-09-30 16:00:00">
+					<div class="post" data-isodate="2023-09-30 16:00:00" data-hash="dfc19e06">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">30</div>
@@ -396,7 +396,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-09-26 21:30:00">
+					<div class="post" data-isodate="2023-09-26 21:30:00" data-hash="a2fca8e3">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">26</div>
@@ -427,7 +427,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-09-24 16:00:00">
+					<div class="post" data-isodate="2023-09-24 16:00:00" data-hash="245f1f2c">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">24</div>
@@ -463,7 +463,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-09-23 16:00:00">
+					<div class="post" data-isodate="2023-09-23 16:00:00" data-hash="1555189d">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">23</div>
@@ -499,7 +499,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-09-23 16:00:00">
+					<div class="post" data-isodate="2023-09-23 16:00:00" data-hash="b6828b26">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">23</div>
@@ -535,7 +535,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-09-17 16:00:00">
+					<div class="post" data-isodate="2023-09-17 16:00:00" data-hash="48300cbc">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">17</div>
@@ -571,7 +571,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-09-12 23:30:00">
+					<div class="post" data-isodate="2023-09-12 23:30:00" data-hash="eb54167a">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">12</div>
@@ -607,7 +607,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-09-06 18:00:00">
+					<div class="post" data-isodate="2023-09-06 18:00:00" data-hash="cae3a88c">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">6</div>
@@ -643,7 +643,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-08-27 16:30:00">
+					<div class="post" data-isodate="2023-08-27 16:30:00" data-hash="e66aa61b">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">27</div>
@@ -679,7 +679,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-08-20 16:00:00">
+					<div class="post" data-isodate="2023-08-20 16:00:00" data-hash="4da9329d">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">20</div>
@@ -715,7 +715,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-08-15 21:30:00">
+					<div class="post" data-isodate="2023-08-15 21:30:00" data-hash="6323f1be">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">15</div>
@@ -746,7 +746,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-08-13 16:00:00">
+					<div class="post" data-isodate="2023-08-13 16:00:00" data-hash="245f1f2c">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">13</div>
@@ -782,7 +782,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-08-08 21:30:00">
+					<div class="post" data-isodate="2023-08-08 21:30:00" data-hash="953163de">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">8</div>
@@ -813,7 +813,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-08-06 16:00:00">
+					<div class="post" data-isodate="2023-08-06 16:00:00" data-hash="335c9857">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">6</div>
@@ -842,7 +842,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-08-01 21:30:00">
+					<div class="post" data-isodate="2023-08-01 21:30:00" data-hash="1ce8aba2">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">1</div>
@@ -873,7 +873,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-07-25 21:30:00">
+					<div class="post" data-isodate="2023-07-25 21:30:00" data-hash="759bebeb">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">25</div>
@@ -904,7 +904,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-07-23 16:00:00">
+					<div class="post" data-isodate="2023-07-23 16:00:00" data-hash="f356998b">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">23</div>
@@ -940,7 +940,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-07-18 21:30:00">
+					<div class="post" data-isodate="2023-07-18 21:30:00" data-hash="dbcd2f7b">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">18</div>
@@ -971,7 +971,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-07-16 16:00:00">
+					<div class="post" data-isodate="2023-07-16 16:00:00" data-hash="e560abc1">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">16</div>
@@ -1007,7 +1007,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-07-11 21:30:00">
+					<div class="post" data-isodate="2023-07-11 21:30:00" data-hash="12cb9928">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">11</div>
@@ -1038,7 +1038,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-07-09 16:00:00">
+					<div class="post" data-isodate="2023-07-09 16:00:00" data-hash="a265e24d">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">9</div>
@@ -1074,7 +1074,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-06-25 16:00:00">
+					<div class="post" data-isodate="2023-06-25 16:00:00" data-hash="d6113cce">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">25</div>
@@ -1110,7 +1110,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-06-18 16:00:00">
+					<div class="post" data-isodate="2023-06-18 16:00:00" data-hash="d85be19b">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">18</div>
@@ -1146,7 +1146,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-06-17 23:00:00">
+					<div class="post" data-isodate="2023-06-17 23:00:00" data-hash="0b3631e5">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">17</div>
@@ -1182,7 +1182,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-06-04 16:00:00">
+					<div class="post" data-isodate="2023-06-04 16:00:00" data-hash="7d44116d">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">4</div>
@@ -1218,7 +1218,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-05-21 16:00:00">
+					<div class="post" data-isodate="2023-05-21 16:00:00" data-hash="e8129134">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">21</div>
@@ -1254,7 +1254,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-05-07 16:00:00">
+					<div class="post" data-isodate="2023-05-07 16:00:00" data-hash="9355f65c">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">7</div>
@@ -1290,7 +1290,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-04-30 16:00:00">
+					<div class="post" data-isodate="2023-04-30 16:00:00" data-hash="5e818028">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">30</div>
@@ -1326,7 +1326,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-04-04 22:30:00">
+					<div class="post" data-isodate="2023-04-04 22:30:00" data-hash="b7210621">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">4</div>
@@ -1362,7 +1362,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-04-02 16:30:00">
+					<div class="post" data-isodate="2023-04-02 16:30:00" data-hash="e66aa61b">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">2</div>
@@ -1398,7 +1398,7 @@
 						</div>
 					</div>
 
-					<div class="post" data-isodate="2023-03-19 16:00:00">
+					<div class="post" data-isodate="2023-03-19 16:00:00" data-hash="6fb9ebb9">
 						<div class="post_header">
 							<div class="calendar_link noselect">
 								<div class="circled_date">19</div>

--- a/posts.json
+++ b/posts.json
@@ -194,6 +194,22 @@
 			"cancelled": false
 		},
 		{
+			"title": "Laser Cutter 101",
+			"subtitle": "Make Your Own Edge-Lit Acrylic Sign",
+			"description": "<p>This workshop covers the Hacksburg 80W CO2 laser cutter. Basic laser safety, design guidelines, and examples will be presented. Attendees will learn how to make their own edge-lit acrylic sign and receive the LED base with the optional materials fee.</p> <p>Free for members and $5 for non-members, plus $10 optional materials fee.</p><p><b>This event has been rescheduled</b></p>",
+			"date": "2023-09-23",
+			"start_time": "2:00pm",
+			"end_time": "4:00pm",
+			"offsite_location": null,
+			"offered_online": false,
+			"offered_in_person": true,
+			"member_price": 10,
+			"non_member_price": 15,
+			"image": "laser_3.jpg",
+			"meetup_link": "https://www.meetup.com/hacksburgva/events/295657648/",
+			"cancelled": false
+		},
+		{
 			"title": "DIY Home Maintenance",
 			"subtitle": "Was that hole always there?",
 			"description": "<p>Learn how to perform basic home repairs and maintenance. Will cover preventative items as well as repairs including: minor drywall patching, unclogging a drain, fixing a leaking faucet or toilet and more.</p> <p>If there is a specific repair or maintenance item you would like to see, please let us know!</p> <p>$5 for members and $10 for non-members.</p>",
@@ -223,22 +239,6 @@
 			"non_member_price": 0,
 			"image": "laser_taco_tuesday.jpg",
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/295658678/",
-			"cancelled": false
-		},
-		{
-			"title": "Laser Cutter 101",
-			"subtitle": "Make Your Own Edge-Lit Acrylic Sign",
-			"description": "<p>This workshop covers the Hacksburg 80W CO2 laser cutter. Basic laser safety, design guidelines, and examples will be presented. Attendees will learn how to make their own edge-lit acrylic sign and receive the LED base with the optional materials fee.</p> <p>Free for members and $5 for non-members, plus $10 optional materials fee.</p><p><b>This event has been rescheduled</b></p>",
-			"date": "2023-09-23",
-			"start_time": "2:00pm",
-			"end_time": "4:00pm",
-			"offsite_location": null,
-			"offered_online": false,
-			"offered_in_person": true,
-			"member_price": 10,
-			"non_member_price": 15,
-			"image": "laser_3.jpg",
-			"meetup_link": "https://www.meetup.com/hacksburgva/events/295657648/",
 			"cancelled": false
 		},
 		{

--- a/resources/hacksburg.css
+++ b/resources/hacksburg.css
@@ -230,9 +230,7 @@ body {
 	width: 30px;
 	height: 30px;
 	cursor: pointer;
-	transform: rotate(-45deg);
 	margin-left: auto;
-	transition: transform .15s ease-in-out;
 }
 
 .info {
@@ -268,7 +266,8 @@ body {
 	height: 20px;
 	position: relative;
 	width: 4px;
-	transition: background .15s ease-in-out;
+	transition: background .15s ease-in-out, transform .15s ease-in-out;
+	transform: rotate(-45deg);
 }
 
 .x:after {

--- a/resources/hacksburg.js
+++ b/resources/hacksburg.js
@@ -22,14 +22,20 @@ function undim_current_page() {
 	current_page.style.cssText = "color: var(--darker_green)";
 }
 
-function togglePostOpened(x)
+function togglePostOpened(x_box)
 {
-	closeable = x.parentNode.parentNode.querySelector('.closeable');
+	// get closest parent's data-hash attribute
+	// if it's not in localstorage, store a false and continue
+	// if it is in localstorage, toggle it
+
+	closeable = x_box.parentNode.parentNode.querySelector('.closeable');
 	if (closeable.classList.contains('closed')) {
+		x = x_box.querySelector('.x');
 		x.style.transform = 'rotate(-45deg)';
 		closeable.classList.remove('closed');
 	}
 	else {
+		x = x_box.querySelector('.x');
 		x.style.transform = "rotate(0deg)";
 		closeable.classList.add('closed'); 
 	}

--- a/resources/home.js
+++ b/resources/home.js
@@ -17,7 +17,17 @@ window.addEventListener('DOMContentLoaded', (event) => {
 	let today = new Date();
 
 	// Format today's date to match the 'data-isodate' attribute format
-	let todayFormatted = today.toISOString().substring(0, 10);
+	let todayFormatted = [
+		today.getFullYear(),
+		String(today.getMonth() + 1).padStart(2, '0'),
+		String(today.getDate()).padStart(2, '0')
+	].join('-') + ' ' + [
+		String(today.getHours()).padStart(2, '0'),
+		String(today.getMinutes()).padStart(2, '0'),
+		String(today.getSeconds()).padStart(2, '0')
+	].join(':');
+
+	console.log(todayFormatted);
 
 	// Split posts into future and past
 	let futurePosts = posts.filter(post => post.getAttribute('data-isodate') >= todayFormatted);

--- a/resources/home.js
+++ b/resources/home.js
@@ -27,8 +27,6 @@ window.addEventListener('DOMContentLoaded', (event) => {
 		String(today.getSeconds()).padStart(2, '0')
 	].join(':');
 
-	console.log(todayFormatted);
-
 	// Split posts into future and past
 	let futurePosts = posts.filter(post => post.getAttribute('data-isodate') >= todayFormatted);
 	let pastPosts = posts.filter(post => post.getAttribute('data-isodate') < todayFormatted);


### PR DESCRIPTION
- when clicking the x icon on a post, rotate the x without rotating the hitbox
- add end times to posts' data-isodates, so they get placed below the past events marker the second they conclude (on refresh)

- experimented with saving/loading state of closed posts to/from local storage, but decided against this feature; users who revisit the site after some time may not remember how to toggle closed/open state, so it's probably better to leave them open on refresh.