### PR TITLE
fix references to favicons on about and join pages

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -5,7 +5,7 @@
 		<title>
 			Hacksburg - About - Community Workshop
 		</title>
-		<link rel="icon" href="/resources/hacksignia-light.svg" type="image/svg+xml">
+		<link rel="icon" href="/resources/hacksignia_light.svg" type="image/svg+xml">
 		<link rel="stylesheet" type="text/css" href="/resources/hacksburg.css">
 		<script type="text/javascript" src="/resources/hacksburg.js"></script>
 		<!-- Google tag (gtag.js) -->

--- a/join/index.html
+++ b/join/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Hacksburg - Join - Community Workshop</title>
-		<link rel="icon" href="/resources/hacksignia-light.svg" type="image/svg+xml">
+		<link rel="icon" href="/resources/hacksignia_light.svg" type="image/svg+xml">
 		<link rel="stylesheet" type="text/css" href="/resources/hacksburg.css">
 		<script type="text/javascript" src="/resources/hacksburg.js"></script>
 		<!-- Google tag (gtag.js) -->


### PR DESCRIPTION
- change outdated references to hacksignia-light.svg to hacksignia_light.svg (underscore instead of hyphen) to correctly display favicons on about and join pages