### PR TITLE
remove thanksgiving-week meeting announcement

### DIFF
--- a/posts.json
+++ b/posts.json
@@ -1,11 +1,5 @@
 {
-	"announcements": [
-		{
-			"title": "No Meeting on Tuesday, November 26th",
-			"subtitle": "Happy Thanksgiving! \ud83e\udd83",
-			"description": "Hacksburg will not hold its regular weekly meeting on Tuesday, November 26th due to the Thanksgiving holiday. Weekly meetings will resume on Tuesday, December 3rd."
-		}
-	],
+	"announcements": [],
 	"posts": [
 		{
 			"title": "Leatherworking Basics",


### PR DESCRIPTION
- update posts.json to remove "no meeting" announcement