### PR TITLE
use Zeffy for donations instead of PayPal

### DIFF
--- a/donate/index.html
+++ b/donate/index.html
@@ -63,22 +63,22 @@
 									<div id="donation-jar-container">
 										<img src="/resources/images/mason_jar.png" id="donation-jar">
 									</div>
-									<a id="donate-button" class="button green" style="margin-bottom:3rem;" href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=KVUGMTXUKKPAQ" target="_blank">
-										Donate with PayPal
-									</a>
+									<div id="donate-button-container">
+										<a id="donate-button" class="button green" href="https://www.zeffy.com/en-US/donation-form/73634503-039f-4dca-a7d2-3687e1685922" target="_blank">
+											Donate with Zeffy
+										</a>
+										<div class="below-button-text">What's <a href="https://www.youtube.com/watch?v=E2TIFiaER9E" target="_blank">Zeffy</a>?</a></div>
+									</div>
 
 									<div class="post-section" id="monetary">
 										<span class="post-section-header">Monetary Donations</span>
 										<div class="post-text-rule"></div>
 										Monetary donations give Hacksburg the most flexibility to advance our programs and offerings. Monetary donations are accepted via:
-
 										<div class="donation-methods">
 											<div class="donation-method">
-												<span class="post-subsection-header">PayPal</span>
+												<span class="post-subsection-header">Zeffy</span>
 												<div class="post-text-rule-mini"></div>
-												You can <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=KVUGMTXUKKPAQ">donate directly</a> or select Hacksburg as a charity when checking out with PayPal partners like
-												<a href="https://www.charity.ebay.com/charity/i/Hacksburg/107123">eBay</a> and
-												<a href="https://www.humblebundle.com/store?charity=1450011">Humble Bundle</a>.
+												Hacksburg uses <a href="https://www.zeffy.com/en-US/donation-form/73634503-039f-4dca-a7d2-3687e1685922" target="_blank">Zeffy</a> for digital contributions, which allows your entire donation to go directly to Hacksburg without deducting any platform fees.
 											</div>
 
 											<div class="donation-method">
@@ -106,7 +106,7 @@
 									<div class="post-section" id="kroger">
 										<span class="post-section-header">Kroger Community Rewards</span><br>
 										<div class="post-text-rule"></div>
-											Kroger customers can can support Hacksburg every time they shop by enrolling in Kroger Community Rewards.<br><br>
+											Kroger customers can support Hacksburg every time they shop by enrolling in Kroger Community Rewards.<br><br>
 											To enroll:<br>
 											<ol>
 												<li>If you do not have a digital Kroger account, <a href="https://www.kroger.com/account/create">register for one</a> using your Kroger Plus Card. If you already have a digital Kroger account, be sure to <a href="https://www.kroger.com/account/update">link your Kroger Plus Card</a> to your account.</li>

--- a/resources/hacksburg.css
+++ b/resources/hacksburg.css
@@ -387,6 +387,10 @@ a {
 	width: 100%;
 }
 
+#donate-button-container {
+	margin-bottom:3rem;
+}
+
 #donation-jar-container {
 	display: flex;
 	justify-content: center;


### PR DESCRIPTION
- replace PayPal with Zeffy for donations (no changes to membership payments for now)
- fix typo in Kroger Community Rewards section