### PR TITLE
add support for zeffy RSVP links

### DIFF
--- a/build.py
+++ b/build.py
@@ -167,6 +167,132 @@ def json_to_html():
 				html += f'\t\t\t\t\t\t\t\t\t<b>Cost</b>: ${post["member_price"]} for Hacksburg members; ${post["non_member_price"]} for non-members. Pay in person or online at <a href="https://paypal.me/hacksburg" target="_blank">paypal.me/hacksburg</a>.\n'
 			html += '\t\t\t\t\t\t\t\t\t</p>\n'
 
+		# Determine which platform to use for RSVP
+		platform_link = None
+		platform_name = None
+		if post["zeffy_link"]:
+			platform_link = post["zeffy_link"]
+			platform_name = "Zeffy"
+		elif post["meetup_link"]:
+			platform_link = post["meetup_link"]
+			platform_name = "Meetup"
+		
+		if platform_link:
+			if not cancelled:
+				html += f'\t\t\t\t\t\t\t\t\t<a class="button rsvp-button" href="{platform_link}" target="_blank">RSVP on {platform_name}</a>\n'
+				html += '\t\t\t\t\t\t\t\t\t<div class="below-button-text">\n'
+				subject = f'RSVP for {post["title"]}'
+				body = f'I am confirming my RSVP for \"{post["title"]}\" on {formatted_date_str} from {time_string}.'
+				html += f'\t\t\t\t\t\t\t\t\t\tor <a href="{build_mailto(subject, body)}" target="_blank">RSVP by Email</a>\n'
+				html += '\t\t\t\t\t\t\t\t\t</div>\n'
+			else:
+				html += f'\t\t\t\t\t\t\t\t\t<a class="button rsvp-button" href="{platform_link}" target="_blank">View on {platform_name}</a>\n'
+		
+		html += '\t\t\t\t\t\t\t\t</div>\n'
+		html += '\t\t\t\t\t\t\t</div>\n'
+		html += '\t\t\t\t\t\t</div>\n'
+		html += '\t\t\t\t\t</div>\n'
+		
+	return html
+	with open('posts.json') as json_file:
+		data = json.load(json_file)
+		posts = data['posts']
+
+	html = ""
+	for post in posts:
+		date = datetime.strptime(f"{post['date']} {datetime.strptime(post['end_time'], '%I:%M%p').strftime('%H:%M')}", '%Y-%m-%d %H:%M')
+		start_time = post["start_time"]
+		end_time = post["end_time"]
+		cancelled = post["cancelled"]
+
+		# Header
+		html += f'\n\t\t\t\t\t<div class="post" data-isodate="{date}">\n'
+		html += '\t\t\t\t\t\t<div class="post-header">\n'
+		
+		if date and start_time and end_time:
+			html += f'\t\t\t\t\t\t\t<div class="calendar-link noselect">\n'
+			html += f'\t\t\t\t\t\t\t\t<div class="circled-date">{date.day}</div>\n'
+
+			month = date.strftime('%B')
+			html += f'\t\t\t\t\t\t\t\t<div class="month-and-time">{month}<br>\n'
+			
+			start_time = datetime.strptime(start_time, "%I:%M%p").strftime("%-I:%M%p").lower()
+			end_time = datetime.strptime(end_time, "%I:%M%p").strftime("%-I:%M%p").lower()
+			if start_time[-2:] != end_time[-2:]:
+				time_string = f"{start_time} - {end_time}"
+			else:
+				time_string = f"{start_time[:-2]} - {end_time}"
+			html += f'\t\t\t\t\t\t\t\t\t<div class="time">{time_string}</div>\n'
+			html += '\t\t\t\t\t\t\t\t</div>\n'
+			html += '\t\t\t\t\t\t\t</div>\n'
+
+		# Title
+		html += '\t\t\t\t\t\t\t<div class="title-and-subtitle-wrapper">\n'
+		html += '\t\t\t\t\t\t\t\t<div class="title-and-subtitle">\n'
+		html += f'\t\t\t\t\t\t\t\t\t<div class="title">'
+		if cancelled:
+			html += '(Cancelled) '
+		html += f'{post["title"]}</div>\n'
+		html += f'\t\t\t\t\t\t\t\t\t<div class="subtitle">{post["subtitle"]}</div>\n'
+		html += '\t\t\t\t\t\t\t\t</div>\n'
+		html += '\t\t\t\t\t\t\t</div>\n'
+		html += '\t\t\t\t\t\t\t<div class="x-box" onClick="togglePostOpened(this)">\n'
+		html += '\t\t\t\t\t\t\t\t<div class="x"></div>\n'
+		html += '\t\t\t\t\t\t\t</div>\n'
+		html += '\t\t\t\t\t\t</div>\n'
+
+		# Image
+		html += '\t\t\t\t\t\t<div class="closeable">\n'
+		html += '\t\t\t\t\t\t\t<div class="post-body">\n'
+		if post["image"]:
+			html += f'\t\t\t\t\t\t\t\t<img class="post-image" src="/resources/images/{post["image"]}" loading="lazy">\n'
+		html += f'\t\t\t\t\t\t\t\t<div class="post-text"'
+		if post["image"]:
+			html += '>'
+		else:
+			html += ' style="width: 100%">'
+		
+		# Description
+		if cancelled:
+			html += f'<s>{post["description"]}</s>\n'
+			html += '\t\t\t\t\t\t\t\t\t<br><p><b>This event has been cancelled.</b></p>\n'
+		else:
+			html += f'{post["description"]}\n'
+		
+		# Event details (time, location, cost)
+		if not cancelled:
+			html += '\t\t\t\t\t\t\t\t\t<p>\n'
+			if date and start_time and end_time:
+				formatted_date_str = f"{date.strftime('%A')}, {date.strftime('%B')} {date.day}{date_suffix(date.day)}"
+				html += f'\t\t\t\t\t\t\t\t\t<b>Time</b>: {formatted_date_str} from {time_string}<br>\n'
+			
+			location_str = ""
+			if post["offsite_location"]:
+				location_str = post["offsite_location"]
+			elif post["offered_in_person"] and post["offered_online"]:
+				location_str = 'Online and in person at Hacksburg; <a href="https://www.google.com/maps/dir/?api=1&destination=Hacksburg+Blacksburg,+VA" target="_blank">1872 Pratt Drive Suite 1620</a>.<br>\n\t\t\t\t\t\t\t\t\tEnter through the covered double doors at the back of the building.'
+			elif post["offered_in_person"]:
+				location_str = 'In person at Hacksburg; <a href="https://www.google.com/maps/dir/?api=1&destination=Hacksburg+Blacksburg,+VA" target="_blank">1872 Pratt Drive Suite 1620</a>. Enter through the covered double doors at the back of the building.'
+			elif post["offered_online"]:
+				location_str = 'Online only.'
+			
+			if location_str:
+				html += f'\t\t\t\t\t\t\t\t\t<b>Place</b>: {location_str}<br>\n'
+		
+			if post["offered_online"]:
+				html += '\t\t\t\t\t\t\t\t\t<b>URL</b>: '
+				html += '<a href="https://meet.hacksburg.org/class" target="_blank">meet.hacksburg.org/class</a><br>\n'
+
+			if post["member_price"] == 0 and post["non_member_price"] == 0:
+				html += '\t\t\t\t\t\t\t\t\t<b>Cost</b>: Free!\n'
+			elif post["member_price"] == 0:
+				html += f'\t\t\t\t\t\t\t\t\t<b>Cost</b>: Free for Hacksburg members; ${post["non_member_price"]} for non-members. Pay in person or online at <a href="https://paypal.me/hacksburg" target="_blank">paypal.me/hacksburg</a>.\n'
+			elif post["member_price"] == post["non_member_price"]:
+				html += f'\t\t\t\t\t\t\t\t\t<b>Cost</b>: ${post["non_member_price"]}. Pay in person or online at <a href="https://paypal.me/hacksburg" target="_blank">paypal.me/hacksburg</a>.\n'
+			else:
+				html += f'\t\t\t\t\t\t\t\t\t<b>Cost</b>: ${post["member_price"]} for Hacksburg members; ${post["non_member_price"]} for non-members. Pay in person or online at <a href="https://paypal.me/hacksburg" target="_blank">paypal.me/hacksburg</a>.\n'
+			html += '\t\t\t\t\t\t\t\t\t</p>\n'
+
 		# Meetup/RSVP link
 		if post["meetup_link"]:
 			if not cancelled:

--- a/posts.json
+++ b/posts.json
@@ -14,6 +14,7 @@
 			"member_price": 5,
 			"non_member_price": 5,
 			"image": "leatherworking.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/304162117/",
 			"cancelled": false
 		},
@@ -30,6 +31,7 @@
 			"member_price": 5,
 			"non_member_price": 10,
 			"image": "radio.jpg",
+			"zeffy_link": "https://www.zeffy.com/ticketing/intro-to-electronics-with-radios",
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/304162112/",
 			"cancelled": false
 		},
@@ -46,6 +48,7 @@
 			"member_price": 5,
 			"non_member_price": 10,
 			"image": "maple_syrup.jpg",
+			"zeffy_link": "https://www.zeffy.com/ticketing/maple-syrup-making",
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/304162109/",
 			"cancelled": false
 		},
@@ -62,6 +65,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "3dprinting_2.jpg",
+			"zeffy_link": "https://www.zeffy.com/ticketing/3d-printer-community-work-day",
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/304162120",
 			"cancelled": false
 		},
@@ -78,6 +82,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "kite.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/304162108/",
 			"cancelled": false
 		},
@@ -94,6 +99,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": "2018_all_ornaments.png",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/304162104/",
 			"cancelled": false
 		},
@@ -110,6 +116,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "cnc.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/304162094/",
 			"cancelled": false
 		},
@@ -126,6 +133,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "casting_cropped_600px.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/304162061/",
 			"cancelled": false
 		},
@@ -142,6 +150,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "fermentation.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/302852570/",
 			"cancelled": false
 		},
@@ -158,6 +167,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": "2018_cidermaking.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/302852557/",
 			"cancelled": false
 		},
@@ -174,6 +184,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": "2018_cidermaking.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/302852550/",
 			"cancelled": false
 		},
@@ -190,6 +201,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": "maple.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/303331401/",
 			"cancelled": false
 		},
@@ -206,6 +218,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": "laser_taco_tuesday.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/303331426/",
 			"cancelled": false
 		},
@@ -222,6 +235,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "kicad.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/302852534/",
 			"cancelled": false
 		},
@@ -238,6 +252,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": "lunar_eclipse.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/303331375/",
 			"cancelled": false
 		},
@@ -254,6 +269,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "resin_print_3.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/302852523/",
 			"cancelled": false
 		},
@@ -270,6 +286,7 @@
 			"member_price": 10,
 			"non_member_price": 15,
 			"image": "glow_cat.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/302852515/",
 			"cancelled": false
 		},
@@ -286,6 +303,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "casting_cropped_600px.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/301640287/",
 			"cancelled": false
 		},
@@ -302,6 +320,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "canning.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/301640285/",
 			"cancelled": false
 		},
@@ -318,6 +337,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "cnc.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/301640304/",
 			"cancelled": false
 		},
@@ -334,6 +354,7 @@
 			"member_price": 5,
 			"non_member_price": 10,
 			"image": "embroidery.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/301640951/",
 			"cancelled": false
 		},
@@ -350,6 +371,7 @@
 			"member_price": 5,
 			"non_member_price": 10,
 			"image": "vinyl_cutter.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/301640635/",
 			"cancelled": false
 		},
@@ -366,6 +388,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "home_assistant.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/301640274/",
 			"cancelled": false
 		},
@@ -382,6 +405,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "cnc.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/301640259/",
 			"cancelled": false
 		},
@@ -398,6 +422,7 @@
 			"member_price": 10,
 			"non_member_price": 15,
 			"image": "glow_cat.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/301471529/",
 			"cancelled": false
 		},
@@ -414,6 +439,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "homebrewing.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/301640249/",
 			"cancelled": false
 		},
@@ -430,6 +456,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": "woodshop2.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/301471792/",
 			"cancelled": false
 		},
@@ -446,6 +473,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": "summer_solstice_fest2.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/301471805/",
 			"cancelled": false
 		},
@@ -462,6 +490,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "resin_print_3.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/301294492/",
 			"cancelled": false
 		},
@@ -478,6 +507,7 @@
 			"member_price": 30,
 			"non_member_price": 35,
 			"image": "wooden_box_2.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/301294474/",
 			"cancelled": false
 		},
@@ -494,6 +524,7 @@
 			"member_price": 15,
 			"non_member_price": 20,
 			"image": "holograms.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/300620652/",
 			"cancelled": false
 		},
@@ -510,6 +541,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "kicad.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/300620550/",
 			"cancelled": false
 		},
@@ -526,6 +558,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "kite.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/299197451/",
 			"cancelled": false
 		},
@@ -542,6 +575,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": "shop_workday.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/299197521/",
 			"cancelled": false
 		},
@@ -558,6 +592,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": "laser_room.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/299198664/",
 			"cancelled": false
 		},
@@ -574,6 +609,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": "maker_faire.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/299197476/",
 			"cancelled": false
 		},
@@ -590,6 +626,7 @@
 			"member_price": 15,
 			"non_member_price": 20,
 			"image": "seedstarting.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/299197479/",
 			"cancelled": true
 		},
@@ -606,6 +643,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "bicycles.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/299197487/",
 			"cancelled": true
 		},
@@ -622,6 +660,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "3dprinting_2.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/299197428/",
 			"cancelled": false
 		},
@@ -638,6 +677,7 @@
 			"member_price": 15,
 			"non_member_price": 20,
 			"image": "wooden_lathe.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/298063962/",
 			"cancelled": false
 		},
@@ -654,6 +694,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "cnc.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/298063947/",
 			"cancelled": false
 		},
@@ -670,6 +711,7 @@
 			"member_price": 10,
 			"non_member_price": 15,
 			"image": "laser_3.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/298063931/",
 			"cancelled": false
 		},
@@ -686,6 +728,7 @@
 			"member_price": 30,
 			"non_member_price": 35,
 			"image": "wooden_box_2.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/298063956/",
 			"cancelled": false
 		},
@@ -702,6 +745,7 @@
 			"member_price": 5,
 			"non_member_price": 10,
 			"image": "radio.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/298063942/",
 			"cancelled": false
 		},
@@ -718,6 +762,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "casting_cropped_600px.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/297868632/",
 			"cancelled": false
 		},
@@ -734,6 +779,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "sewing.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/298063946/",
 			"cancelled": false
 		},
@@ -750,6 +796,7 @@
 			"member_price": 5,
 			"non_member_price": 10,
 			"image": "maple_syrup.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/298063923/",
 			"cancelled": false
 		},
@@ -766,6 +813,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "HomeAlone_small.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/297039489/",
 			"cancelled": false
 		},
@@ -782,6 +830,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "casting_cropped_600px.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/297039481/",
 			"cancelled": false
 		},
@@ -798,6 +847,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": "2018_all_ornaments.png",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/297039468/",
 			"cancelled": false
 		},
@@ -814,6 +864,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "resin_print_3.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/297039452/",
 			"cancelled": false
 		},
@@ -830,6 +881,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "sewing.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/297039431/",
 			"cancelled": false
 		},
@@ -846,6 +898,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": null,
+			"zeffy_link": null,
 			"meetup_link": null,
 			"cancelled": false
 		},
@@ -862,6 +915,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "apple_05.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/295657924/",
 			"cancelled": false
 		},
@@ -878,6 +932,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": null,
+			"zeffy_link": null,
 			"meetup_link": null,
 			"cancelled": false
 		},
@@ -894,6 +949,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": "2018_cidermaking.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/295657883/",
 			"cancelled": false
 		},
@@ -910,6 +966,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": "2018_cidermaking.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/295657877/",
 			"cancelled": false
 		},
@@ -926,6 +983,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": null,
+			"zeffy_link": null,
 			"meetup_link": null,
 			"cancelled": false
 		},
@@ -942,6 +1000,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": null,
+			"zeffy_link": null,
 			"meetup_link": null,
 			"cancelled": false
 		},
@@ -958,6 +1017,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "3dprinting_2.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/295657691/",
 			"cancelled": false
 		},
@@ -974,6 +1034,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": "foam_mask.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/295657977/",
 			"cancelled": false
 		},
@@ -990,6 +1051,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": null,
+			"zeffy_link": null,
 			"meetup_link": null,
 			"cancelled": false
 		},
@@ -1006,6 +1068,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "blender.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/295657658/",
 			"cancelled": false
 		},
@@ -1022,6 +1085,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": "maple.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/295657828/",
 			"cancelled": false
 		},
@@ -1038,6 +1102,7 @@
 			"member_price": 10,
 			"non_member_price": 15,
 			"image": "laser_3.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/295657648/",
 			"cancelled": false
 		},
@@ -1054,6 +1119,7 @@
 			"member_price": 5,
 			"non_member_price": 10,
 			"image": "home_maintenance.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/295657781/",
 			"cancelled": false
 		},
@@ -1070,6 +1136,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": "laser_taco_tuesday.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/295658678/",
 			"cancelled": false
 		},
@@ -1086,6 +1153,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": "laser_room.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/295210629/",
 			"cancelled": false
 		},
@@ -1102,6 +1170,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "cnc.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/295114339/",
 			"cancelled": false
 		},
@@ -1118,6 +1187,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "canning.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/295114326/",
 			"cancelled": false
 		},
@@ -1134,6 +1204,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": null,
+			"zeffy_link": null,
 			"meetup_link": null,
 			"cancelled": false
 		},
@@ -1150,6 +1221,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "blender.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/295114315/",
 			"cancelled": false
 		},
@@ -1166,6 +1238,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": null,
+			"zeffy_link": null,
 			"meetup_link": null,
 			"cancelled": false
 		},
@@ -1182,6 +1255,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "python.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/295114282/",
 			"cancelled": true
 		},
@@ -1198,6 +1272,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": null,
+			"zeffy_link": null,
 			"meetup_link": null,
 			"cancelled": false
 		},
@@ -1214,6 +1289,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": null,
+			"zeffy_link": null,
 			"meetup_link": null,
 			"cancelled": false
 		},
@@ -1230,6 +1306,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "python.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/294227465/",
 			"cancelled": false
 		},
@@ -1246,6 +1323,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": null,
+			"zeffy_link": null,
 			"meetup_link": null,
 			"cancelled": false
 		},
@@ -1262,6 +1340,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "bicycles.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/294227436/",
 			"cancelled": false
 		},
@@ -1278,6 +1357,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": null,
+			"zeffy_link": null,
 			"meetup_link": null,
 			"cancelled": false
 		},
@@ -1294,6 +1374,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "3dprinting_2.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/294227406/",
 			"cancelled": false
 		},
@@ -1310,6 +1391,7 @@
 			"member_price": 5,
 			"non_member_price": 5,
 			"image": "leatherworking.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/294089600/",
 			"cancelled": false
 		},
@@ -1326,6 +1408,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": "locker_room.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/292997582/",
 			"cancelled": false
 		},
@@ -1342,6 +1425,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": "summer_solstice_fest.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/293868702/",
 			"cancelled": false
 		},
@@ -1358,6 +1442,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": "modern_kites.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/292380255/",
 			"cancelled": false
 		},
@@ -1374,6 +1459,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "modifying_cad.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/292997667/",
 			"cancelled": false
 		},
@@ -1390,6 +1476,7 @@
 			"member_price": 5,
 			"non_member_price": 10,
 			"image": "radio.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/292997547/",
 			"cancelled": false
 		},
@@ -1406,6 +1493,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "resin_print_3.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/292380272/",
 			"cancelled": false
 		},
@@ -1422,6 +1510,7 @@
 			"member_price": 0,
 			"non_member_price": 0,
 			"image": "synthesizer.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/292380091/",
 			"cancelled": false
 		},
@@ -1438,6 +1527,7 @@
 			"member_price": 0,
 			"non_member_price": 5,
 			"image": "cnc.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/292380004/",
 			"cancelled": false
 		},
@@ -1454,6 +1544,7 @@
 			"member_price": 15,
 			"non_member_price": 20,
 			"image": "seedstarting.jpg",
+			"zeffy_link": null,
 			"meetup_link": "https://www.meetup.com/hacksburgva/events/291358474/",
 			"cancelled": false
 		}

--- a/resources/home.js
+++ b/resources/home.js
@@ -121,9 +121,10 @@ function splitAndSortPosts(posts, todayFormatted) {
 	let pastPosts = posts.filter(post => post.getAttribute('data-isodate') < todayFormatted);
 
 	pastPosts.forEach(post => {
+		// Find and remove the RSVP button and the "or RSVP by Email" text below it
 		let rsvpButton = post.querySelector('.rsvp-button');
 		if (rsvpButton) {
-			rsvpButton.innerText = 'View on Meetup';
+			rsvpButton.remove();
 		}
 		let belowButtonText = post.querySelector('.below-button-text');
 		if (belowButtonText) {
@@ -135,6 +136,7 @@ function splitAndSortPosts(posts, todayFormatted) {
 
 	return [futurePosts, pastPosts];
 }
+
 
 function insertSortedPosts(parent, futurePosts, pastPosts, todayFormatted) {
 	// Insert sorted posts and add a marker for past events


### PR DESCRIPTION
- add zeffy_link field to posts.json
- update build.py to prioritize zeffy links over meetup links (if they exist)
- update home.js to hide RSVP buttons for past events (rather than displaying "View on Meetup" or "View on Zeffy")