### PR TITLE
use google form for membership cancellation

### DIFF
--- a/join/index.html
+++ b/join/index.html
@@ -196,7 +196,7 @@
 										<span class="post-subsection-header">Unsubscribe</span>
 										<div class="post-text-rule-mini"></div>
 										To cancel an active subsciption, use the button below. Your membership will remain active until the end of your current membership term. For assistance, contact Hacksburg's board of directors at <a href="mailto:board@hacksburg.org">board@hacksburg.org</a>.</div>
-										<a class="button unsubscribe" href="https://www.paypal.com/cgi-bin/webscr?cmd=_subscr-find&alias=3G6D8WWSMSNSN" target="_blank">Unsubscribe</a>
+										<a class="button unsubscribe" href="https://docs.google.com/forms/d/e/1FAIpQLSfhrYxSGteJM7GBFChpRBbI41qoQ0XYFwYyMTdSCMaw7zosYA/viewform" target="_blank">Unsubscribe</a>
 									</div>
 
 								</div>


### PR DESCRIPTION
paypal's unsubscription method often fails, so for now, let's have users submit a google form so we can manually cancel their subscription